### PR TITLE
CSCQVAIN-122: Issued field

### DIFF
--- a/src/components/Date.vue
+++ b/src/components/Date.vue
@@ -1,30 +1,54 @@
 <template>
-	<div>
-		<legend class="col-form-label pt-0">{{ property.charAt(0).toUpperCase() + property.slice(1) }}</legend>
-		<div class="wrapper">
-			<p>Select date:</p>
-			<datepicker class="widget ml-2"
-				placeholder="Click to select"
-				v-model="date">
-			</datepicker>
+	<record-field :wrapped="wrapped">
+		<title-component slot="title" :title="uiLabel" />
+		<div slot="header-right">
+			<InfoIcon :description="uiDescription"/>
 		</div>
-	</div>
+
+		<div slot="input">
+			<div class="wrap">
+				<p>Select date:</p>
+				<datepicker class="widget ml-2"
+					placeholder="Click to select"
+					v-model="date">
+				</datepicker>
+			</div>
+
+			<delete-button v-if="date !== null" @click="clear()" />
+		</div>
+	</record-field>
 </template>
 
 <script>
-import datepicker from 'vuejs-datepicker'
+import Datepicker from 'vuejs-datepicker'
 import SchemaBase from '@/widgets/base.vue'
+import DeleteButton from '@/partials/DeleteButton.vue'
+import InfoIcon from '@/partials/InfoIcon.vue'
+import RecordField from '@/composites/RecordField.vue'
+import TitleComponent from '@/partials/Title.vue'
 
 export default {
 	name: 'date',
 	extends: SchemaBase,
 	components: {
-		datepicker,
+		Datepicker,
+		DeleteButton,
+		InfoIcon,
+		RecordField,
+		TitleComponent,
+	},
+	props: {
+		wrapped: { type: Boolean, default: false },
 	},
 	data() {
 		return {
 			date: null,
 		}
+	},
+	methods: {
+		clear() {
+			this.date = null
+		},
 	},
 	computed: {
 		dateString() {
@@ -53,12 +77,13 @@ export default {
 
 
 <style lang="scss" scoped>
-	.wrapper {
+	.wrap {
 		display: inline-flex;
 		> p {
 			line-height: 40px;
 			vertical-align: middle;
 		}
+		margin-right: 6px;
 	}
 </style>
 

--- a/src/partials/DeleteButton.vue
+++ b/src/partials/DeleteButton.vue
@@ -1,5 +1,5 @@
 <template functional>
-	<span class="delete-button" variant="link" v-on:click="listeners.click">
+	<span class="pointer delete-button" variant="link" v-on:click="listeners.click">
 		<font-awesome-icon icon="times" fixed-width class="icon" />
 	</span>
 </template>

--- a/src/schemas/fairdata-ida.ui.js
+++ b/src/schemas/fairdata-ida.ui.js
@@ -9,7 +9,7 @@ export default {
 		{ label: 'Extra', uri: null },
 	],
 	//'': { 'tab': 'description' },
-	'': { 'tab': 'extra', 'order': ["title", "description", "language"] },
+	'': { 'tab': 'extra', 'order': ["title", "description", "issued", "language"] },
 	//'': { 'tab': 'extra' },
 	'#/definitions/langString': {
 		'widget': 'i18n-string',
@@ -53,6 +53,16 @@ export default {
 		'widget': "schema-array",
 		'props': {
 			'tabFormat': false,
+		},
+	},
+	'/properties/issued': {
+		'tab': 'description',		
+		'title': 'Issued',
+		'label': 'Issued',
+		'description': 'Date of formal issuance (e.g., publication) of the resource. This value does not affect or reflect the visibility of the dataset itself.',
+		'widget': 'date',
+		'props': {
+			'wrapped': true,
 		},
 	},
 	'/properties/language': {
@@ -627,6 +637,7 @@ export default {
 	},
 	'/properties/access_rights/properties/available': {
 		'widget': 'date',
+		'description': "Date when the resource became or will become available.",
 	},
 	'/properties/access_rights/properties/restriction_grounds': {
 		'widget': 'reference-data',
@@ -665,12 +676,6 @@ export default {
 		'tab': 'extra',
 		'title': "Publisher",
 		'description': "*** description for publisher goes here ***",
-	},
-	'/properties/issued': {
-		'tab': 'extra',
-		'title': "Issued",
-		'description': "*** description for issued goes here ***",
-		'widget': 'date',
 	},
 	'/properties/modified': {
 		'tab': 'extra',


### PR DESCRIPTION
Show Issued field in the Content Description tab.

Also:
- allow wrapping date fields (i.e. show a rectangle around the component if the 'wrapped' prop is set)
- allow clearing date fields (fixes CSCQVAIN-121)
- show info icon for date fields
