### PR TITLE
CSCQVAIN-127: Routing/editor changes to prevent editor getting invalid state

### DIFF
--- a/src/navigation.vue
+++ b/src/navigation.vue
@@ -62,7 +62,7 @@ Weekdays from 8:30 AM to 4 PM" href="mailto:servicedesk@csc.fi?subject=Fairdata%
 			<b-collapse is-nav id="app-subbar-collapse">
 				<b-navbar-nav>
 					<b-nav-item v-if="$route.path !== '/datasets'" to="/datasets">My Datasets</b-nav-item>
-					<b-nav-item v-else to="/dataset/new">Editor</b-nav-item>
+					<b-nav-item v-else :to="editorUrl">Editor</b-nav-item>
 				</b-navbar-nav>
 			</b-collapse>
 		</b-navbar>
@@ -139,6 +139,17 @@ export default {
 	data: function() {
 		return {
 		}
+	},
+	computed: {
+		editorUrl() {
+			if (this.$store.state.metadata.id) {
+				return "/dataset/" + this.$store.state.metadata.id
+			} else if (this.$store.state.record) {
+				return "/dataset/edit"
+			} else {
+				return "/dataset/new"
+			}
+		},
 	},
 	methods: {
 		logout() {

--- a/src/router.js
+++ b/src/router.js
@@ -23,7 +23,7 @@ const routes = [
 	{ path: '/', name: "home", component: Welcome, props: true },
 	{ path: '/token', component: Token, props: false },
 	{ path: '/records', component: RecordList, props: false, meta: { auth: true } },
-	{ path: '/datasets', component: Datasets, props: false, meta: { auth: true } },
+	{ path: '/datasets', name: "datasets", component: Datasets, props: false, meta: { auth: true } },
 	{ path: '/viewschema', component: SchemaViewer, props: false },
 	{ path: '/autocomplete', component: testAutoComplete, props: false },
 	{ path: '/orcid', component: OrcidSearch, props: false },
@@ -33,11 +33,10 @@ const routes = [
 	{ path: '/config', component: Config, props: false },
 	{ path: '/userinfo', component: UserInfo, props: false, meta: { auth: true } },
 	{ path: '/dataset/:id', name: "editor", component: Editor, props: true, meta: { auth: true }, children: [
-		{ path: '', redirect: { name: 'tab' } },
 		{ path: ':tab', name: "tab", component: SingleTab },
 		{ path: ':tab/:project?/:relpath*', name: 'files', component: SingleTab }, // what is this for?
 	]},
-	{ path: '*', redirect: { name: 'home' } }
+	{ path: '*', redirect: { name: 'home' } },
 ]
 
 // mode: history or hash

--- a/src/views/Datasets.vue
+++ b/src/views/Datasets.vue
@@ -192,7 +192,7 @@ export default {
 			}
 		},
 		open(id) { // should maybe later be changed to link so that accessability is better
-			this.$router.push({ name: 'tab', params: { id: id, tab: 'description' }})
+			this.$router.push({ name: 'editor', params: { id: id }})
 		},
 		async del() {
 			this.error = null
@@ -259,7 +259,7 @@ export default {
 			this.$store.commit('loadSchema', {})
 			this.$store.commit('loadHints', {})
 
-			this.$router.replace({ name: 'tab', params: { id: 'new', tab: 'description' }})
+			this.$router.replace({ name: 'editor', params: { id: 'new' }})
 		},
 	},
 	computed: {

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -88,17 +88,15 @@
 				</b-button-group>
 			</div>
 
-			<div v-else :style="{'padding': '20px'}">
-				Please select one option from "Where are my files" menu. Note that the selected option cannot be changed without creating a new dataset.
-				<br>
-				<br>
-				Where are your files related to this dataset:
-				<ul>
-					<li>In Fairdata IDA (you want to select files from IDA)" and "I want to select Fairdata IDA files"</li>
-					<li>Somewhere else (you want to link files from remote location)</li>
-				</ul>
-			</div>
+			<div v-else class="schema-help-text">
+				<p>Please select one option from "Where are my files" menu. Note that the selected option cannot be changed without creating a new dataset.</p>
 
+				<p>Where are your files related to this dataset:
+				<ul>
+				<li>In Fairdata IDA (you want to select files from IDA)" and "I want to select Fairdata IDA files"</li>
+				<li>Somewhere else (you want to link files from remote location)</li>
+				</ul></p>
+			</div>
 		</div>
 		<div v-else>
 			<font-awesome-icon icon="circle-notch" spin />
@@ -414,5 +412,9 @@ export default {
 
 .limited-width {
 	max-width: 1100px;
+}
+
+.schema-help-text {
+	padding: 20px;
 }
 </style>

--- a/src/views/SingleTab.vue
+++ b/src/views/SingleTab.vue
@@ -1,15 +1,5 @@
 <template>
 	<TabSelector v-if="Object.keys($store.state.schema).length > 0" :schema="$store.state.schema" path="" :parent="$store.state" property="record" :value="$store.state.record" :activeTab="$route.params.tab" :depth="0"></TabSelector>
-	<div v-else :style="{'padding': '20px'}">
-		Please select one option from "Where are my files" menu. Note that the selected option cannot be changed without creating a new dataset.
-		<br>
-		<br>
-		Where are your files related to this dataset:
-		<ul>
-			<li>In Fairdata IDA (you want to select files from IDA)" and "I want to select Fairdata IDA files"</li>
-			<li>Somewhere else (you want to link files from remote location)</li>
-		</ul>
-	</div>
 </template>
 
 <script>

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -34,7 +34,7 @@
 			<p><a :href="$auth.loginUrl" class="btn btn-info btn-lg" role="button">Login now!</a></p>
 		</div>
 
-		<p v-else><router-link class="btn btn-info btn-lg" to="/dataset/new/description" role="button">Create a new dataset now!</router-link></p>
+		<p v-else><router-link class="btn btn-info btn-lg" to="/dataset/new" role="button">Create a new dataset now!</router-link></p>
 	</b-jumbotron>
 </template>
 


### PR DESCRIPTION
You no longer need to specify a tab when making a link to the editor. The selected schema of the current dataset and active tab are now restored from store when reopening the Editor from the datasets view.

Route changes:
- /dataset/new always gives you a new dataset
- /dataset/edit opens the current dataset from store
- /dataset/[dataset_id] opens a dataset from store (if it is the current one) or from the back-end
